### PR TITLE
3.5 totvs

### DIFF
--- a/cachet/config.go
+++ b/cachet/config.go
@@ -10,19 +10,21 @@ import (
 )
 
 type CachetMonitor struct {
-	SystemName  string                   `json:"system_name" yaml:"system_name"`
-	DateFormat  string                   `json:"date_format" yaml:"date_format"`
-	API         CachetAPI                `json:"api"`
-	RawMonitors []map[string]interface{} `json:"monitors" yaml:"monitors"`
-
+	SystemName  string                   	`json:"system_name" yaml:"system_name"`
+	DateFormat	string                   	`json:"date_format" yaml:"date_format"`
+	API	CachetAPI                			`json:"api"`
+	RawMonitors	[]map[string]interface{} 	`json:"monitors" yaml:"monitors"`
+	Defconf	DefaultConfig					`yaml:"default_config"`	
 	Monitors  []MonitorInterface `json:"-" yaml:"-"`
 	Immediate bool               `json:"-" yaml:"-"`
 }
 
+var Mondef *DefaultConfig
+
 // Validate configuration
 func (cfg *CachetMonitor) Validate() bool {
 	valid := true
-
+	
 	if len(cfg.SystemName) == 0 {
 		// get hostname
 		cfg.SystemName = getHostname()
@@ -41,6 +43,8 @@ func (cfg *CachetMonitor) Validate() bool {
 		logrus.Warnf("No monitors defined!\nSee help for example configuration")
 		valid = false
 	}
+
+	Mondef = &cfg.Defconf
 
 	for index, monitor := range cfg.Monitors {
 		if errs := monitor.Validate(); len(errs) > 0 {

--- a/cachet/config.go
+++ b/cachet/config.go
@@ -10,13 +10,13 @@ import (
 )
 
 type CachetMonitor struct {
-	SystemName  string                   	`json:"system_name" yaml:"system_name"`
-	DateFormat	string                   	`json:"date_format" yaml:"date_format"`
-	API	CachetAPI                			`json:"api"`
-	RawMonitors	[]map[string]interface{} 	`json:"monitors" yaml:"monitors"`
-	Defconf	DefaultConfig					`yaml:"default_config"`	
-	Monitors  []MonitorInterface `json:"-" yaml:"-"`
-	Immediate bool               `json:"-" yaml:"-"`
+	SystemName  string                   `json:"system_name" yaml:"system_name"`
+	DateFormat  string                   `json:"date_format" yaml:"date_format"`
+	API         CachetAPI                `json:"api"`
+	Defconf     DefaultConfig            `json:"default_config" yaml:"default_config"`
+	RawMonitors []map[string]interface{} `json:"monitors" yaml:"monitors"`
+	Monitors    []MonitorInterface       `json:"-" yaml:"-"`
+	Immediate   bool                     `json:"-" yaml:"-"`
 }
 
 var Mondef *DefaultConfig
@@ -24,7 +24,7 @@ var Mondef *DefaultConfig
 // Validate configuration
 func (cfg *CachetMonitor) Validate() bool {
 	valid := true
-	
+
 	if len(cfg.SystemName) == 0 {
 		// get hostname
 		cfg.SystemName = getHostname()

--- a/cachet/default.go
+++ b/cachet/default.go
@@ -1,0 +1,76 @@
+package cachet
+
+import (
+	"time"
+)
+
+const DefaultInterval = time.Second * 60
+const DefaultTimeout = time.Second
+const DefaultTimeFormat = "15:04:05 Jan 2 MST"
+const DefaultHistorySize = 10
+const DefaultthresholdCritical = 60
+const DefaultthresholdPartial = 40
+const DefaultExpectedStatusCode = 200
+
+type DefaultConfig struct {
+	DefInterval           int `json:"def_interval" yaml:"def_interval"`
+	DefTimeout            int `json:"def_timeout" yaml:"def_timeout"`
+	DefHistorySize        int `json:"def_history_size" yaml:"def_history_size"`
+	DefThresholdCritical  int `json:"def_threshold_critical" yaml:"def_threshold_critical"`
+	DefThresholdPartial   int `json:"def_threshold_partial" yaml:"def_threshold_partial"`
+	DefExpectedStatusCode int `json:"def_expected_status_code" yaml:"def_expected_status_code"`
+}
+
+func (Def *DefaultConfig) GetDefInterval() time.Duration {
+	if Def.DefInterval <= 0 {
+		return DefaultInterval
+	} else {
+		return time.Second * time.Duration(Def.DefInterval)
+	}
+
+}
+
+func (Def *DefaultConfig) GetDefTimeOut() time.Duration {
+	if Def.DefTimeout <= 0 {
+		return DefaultTimeout
+	} else {
+		return time.Second * time.Duration(Def.DefTimeout)
+	}
+
+}
+
+func (Def *DefaultConfig) GetDefHistorySize() int {
+	if Def.DefHistorySize <= 0 {
+		return DefaultHistorySize
+	} else {
+		return Def.DefHistorySize
+	}
+
+}
+
+func (Def *DefaultConfig) GetDefThresholdCritical() int {
+	if Def.DefThresholdCritical <= 0 {
+		return DefaultthresholdCritical
+	} else {
+		return Def.DefThresholdCritical
+	}
+
+}
+
+func (Def *DefaultConfig) GetDefThresholdPartial() int {
+	if Def.DefThresholdPartial <= 0 {
+		return DefaultthresholdPartial
+	} else {
+		return Def.DefThresholdPartial
+	}
+
+}
+
+func (Def *DefaultConfig) GetExpectedStatusCode() int {
+	if Def.DefExpectedStatusCode <= 0 {
+		return DefaultExpectedStatusCode
+	} else {
+		return Def.DefExpectedStatusCode
+	}
+
+}

--- a/cachet/default.go
+++ b/cachet/default.go
@@ -8,9 +8,10 @@ const DefaultInterval = time.Second * 60
 const DefaultTimeout = time.Second
 const DefaultTimeFormat = "15:04:05 Jan 2 MST"
 const DefaultHistorySize = 10
-const DefaultthresholdCritical = 60
-const DefaultthresholdPartial = 40
-const DefaultExpectedStatusCode = 200
+const DefaultTholdCrit = 60
+const DefaultTholdPart = 40
+const DefaultExpStsCode = 200
+const DefContentType = "text/plain"
 
 type DefaultConfig struct {
 	DefInterval           int `json:"def_interval" yaml:"def_interval"`
@@ -19,6 +20,38 @@ type DefaultConfig struct {
 	DefThresholdCritical  int `json:"def_threshold_critical" yaml:"def_threshold_critical"`
 	DefThresholdPartial   int `json:"def_threshold_partial" yaml:"def_threshold_partial"`
 	DefExpectedStatusCode int `json:"def_expected_status_code" yaml:"def_expected_status_code"`
+
+	DefWebhook struct {
+		DefOnCritical struct {
+			DefContentType string `yaml:"def_on_critical_content_type"`
+			DefURL         string `yaml:"def_on_critical_url"`
+
+			DefInvestigating struct {
+				DefMessage string `yaml:"def_message"`
+			} `yaml:"def_investigating"`
+		} `yaml:"def_on_critical"`
+
+		DefOnPartial struct {
+			DefContentType string `yaml:"def_on_partial_content_type"`
+			DefURL         string `yaml:"def_on_partial_url"`
+
+			DefInvestigating struct {
+				DefMessage string `yaml:"def_message"`
+			} `yaml:"def_investigating"`
+		} `yaml:"def_on_partial"`
+	} `yaml:"def_webhook"`
+
+	DefTemplate struct {
+		DefInvestigating struct {
+			DefSubJect string `yaml:"def_subject"`
+			DefMessage string `yaml:"def_message"`
+		} `yaml:"def_investigating"`
+
+		DefFixed struct {
+			DefSubJect string `yaml:"def_subject"`
+			DefMessage string `yaml:"def_message"`
+		} `yaml:"def_fixed"`
+	} `yaml:"def_template"`
 }
 
 func (Def *DefaultConfig) GetDefInterval() time.Duration {
@@ -27,7 +60,6 @@ func (Def *DefaultConfig) GetDefInterval() time.Duration {
 	} else {
 		return time.Second * time.Duration(Def.DefInterval)
 	}
-
 }
 
 func (Def *DefaultConfig) GetDefTimeOut() time.Duration {
@@ -36,7 +68,6 @@ func (Def *DefaultConfig) GetDefTimeOut() time.Duration {
 	} else {
 		return time.Second * time.Duration(Def.DefTimeout)
 	}
-
 }
 
 func (Def *DefaultConfig) GetDefHistorySize() int {
@@ -48,29 +79,94 @@ func (Def *DefaultConfig) GetDefHistorySize() int {
 
 }
 
-func (Def *DefaultConfig) GetDefThresholdCritical() int {
+func (Def *DefaultConfig) GetDefTholdCritical() int {
 	if Def.DefThresholdCritical <= 0 {
-		return DefaultthresholdCritical
+		return DefaultTholdCrit
 	} else {
 		return Def.DefThresholdCritical
 	}
 
 }
 
-func (Def *DefaultConfig) GetDefThresholdPartial() int {
+func (Def *DefaultConfig) GetDefTholdPartial() int {
 	if Def.DefThresholdPartial <= 0 {
-		return DefaultthresholdPartial
+		return DefaultTholdPart
 	} else {
 		return Def.DefThresholdPartial
 	}
-
 }
 
-func (Def *DefaultConfig) GetExpectedStatusCode() int {
+func (Def *DefaultConfig) GetExpStsCode() int {
 	if Def.DefExpectedStatusCode <= 0 {
-		return DefaultExpectedStatusCode
+		return DefaultExpStsCode
 	} else {
 		return Def.DefExpectedStatusCode
 	}
+}
 
+func (Def *DefaultConfig) GetWCritContent() string {
+	if len(Def.DefWebhook.DefOnCritical.DefContentType) == 0 {
+		return DefContentType
+	} else {
+		return Def.DefWebhook.DefOnCritical.DefContentType
+	}
+}
+
+func (Def *DefaultConfig) GetWCritUrl() string {
+	return Def.DefWebhook.DefOnCritical.DefURL
+}
+
+func (Def *DefaultConfig) GetWCritMessage() string {
+	return Def.DefWebhook.DefOnCritical.DefInvestigating.DefMessage
+}
+
+func (Def *DefaultConfig) GetWPartContent() string {
+	if len(Def.DefWebhook.DefOnPartial.DefContentType) == 0 {
+		return DefContentType
+	} else {
+		return Def.DefWebhook.DefOnPartial.DefContentType
+	}
+}
+
+func (Def *DefaultConfig) GetWPartUrl() string {
+	return Def.DefWebhook.DefOnPartial.DefURL
+}
+
+func (Def *DefaultConfig) GetWPartMessage() string {
+	return Def.DefWebhook.DefOnCritical.DefInvestigating.DefMessage
+}
+
+func (Def *DefaultConfig) GetTempInvSub(s string) string {
+	if len(Def.DefTemplate.DefInvestigating.DefSubJect) == 0 {
+		return s
+	} else {
+
+		return Def.DefTemplate.DefInvestigating.DefSubJect
+	}
+}
+
+func (Def *DefaultConfig) GetTempInvMes(s string) string {
+	if len(Def.DefTemplate.DefInvestigating.DefMessage) == 0 {
+		return s
+	} else {
+		return Def.DefTemplate.DefInvestigating.DefMessage
+	}
+}
+
+func (Def *DefaultConfig) GetTempFixSub(s string) string {
+
+	if len(Def.DefTemplate.DefFixed.DefSubJect) == 0 {
+		return s
+	} else {
+		return Def.DefTemplate.DefFixed.DefSubJect
+	}
+}
+
+func (Def *DefaultConfig) GetTempFixMes(s string) string {
+
+	if len(Def.DefTemplate.DefFixed.DefMessage) == 0 {
+		return s
+	} else {
+		return Def.DefTemplate.DefFixed.DefMessage
+	}
 }

--- a/cachet/http.go
+++ b/cachet/http.go
@@ -134,7 +134,7 @@ func (mon *HTTPMonitor) Validate() []string {
 	}
 
 	if mon.ExpectedStatusCode <= 0 {
-		mon.ExpectedStatusCode = Mondef.GetExpectedStatusCode()
+		mon.ExpectedStatusCode = Mondef.GetExpStsCode()
 	}
 
 	if len(mon.ExpectedBody) == 0 && mon.ExpectedStatusCode == 0 {

--- a/cachet/http.go
+++ b/cachet/http.go
@@ -133,6 +133,10 @@ func (mon *HTTPMonitor) Validate() []string {
 		errs = append(errs, "'Target' has not been set")
 	}
 
+	if mon.ExpectedStatusCode <= 0 {
+		mon.ExpectedStatusCode = Mondef.GetExpectedStatusCode()
+	}
+
 	if len(mon.ExpectedBody) == 0 && mon.ExpectedStatusCode == 0 {
 		errs = append(errs, "Both 'expected_body' and 'expected_status_code' fields empty")
 	}

--- a/cachet/monitor.go
+++ b/cachet/monitor.go
@@ -2,7 +2,6 @@ package cachet
 
 import (
 	"bytes"
-	"fmt"
 	"net/http"
 	"os/exec"
 	"strconv"
@@ -113,7 +112,7 @@ func (mon *AbstractMonitor) Validate() []string {
 		mon.Interval = Mondef.GetDefInterval()
 
 	}
-	//fmt.Println(mon.Interval)
+
 	if mon.Timeout < time.Second {
 		mon.Timeout = Mondef.GetDefTimeOut()
 	}
@@ -136,24 +135,56 @@ func (mon *AbstractMonitor) Validate() []string {
 	}
 
 	if mon.CriticalThreshold <= 0 {
-		mon.CriticalThreshold = Mondef.GetDefThresholdCritical()
+		mon.CriticalThreshold = Mondef.GetDefTholdCritical()
 	}
 
 	if mon.PartialThreshold <= 0 {
-		mon.PartialThreshold = Mondef.GetDefThresholdPartial()
+		mon.PartialThreshold = Mondef.GetDefTholdPartial()
 	}
 
 	if mon.Threshold == 0 && mon.CriticalThreshold == 0 && mon.PartialThreshold == 0 && mon.ThresholdCount == 0 && mon.CriticalThresholdCount == 0 && mon.PartialThresholdCount == 0 {
 		mon.Threshold = 100
 	}
 
-	fmt.Println("--------------")
-	fmt.Println(mon.Timeout)
-	fmt.Println(mon.Interval)
-	fmt.Println(mon.CriticalThreshold)
-	fmt.Println(mon.PartialThreshold)
-	fmt.Println(mon.HistorySize)
-	fmt.Println("--------------")
+	if len(mon.Webhook.OnCritical.ContentType) == 0 {
+		mon.Webhook.OnCritical.ContentType = Mondef.GetWCritContent()
+	}
+
+	if len(mon.Webhook.OnCritical.URL) == 0 {
+		mon.Webhook.OnCritical.URL = Mondef.GetWCritUrl()
+	}
+
+	if len(mon.Webhook.OnCritical.Investigating.Message) == 0 {
+		mon.Webhook.OnCritical.Investigating.Message = Mondef.GetWCritMessage()
+	}
+
+	if len(mon.Webhook.OnPartial.ContentType) == 0 {
+		mon.Webhook.OnPartial.ContentType = Mondef.GetWPartContent()
+	}
+
+	if len(mon.Webhook.OnPartial.URL) == 0 {
+		mon.Webhook.OnPartial.URL = Mondef.GetWPartUrl()
+	}
+
+	if len(mon.Webhook.OnPartial.Investigating.Message) == 0 {
+		mon.Webhook.OnPartial.Investigating.Message = Mondef.GetWPartMessage()
+	}
+
+	if mon.Template.Investigating.Subject == defaultHTTPInvestigatingTpl.Subject {
+		mon.Template.Investigating.Subject = Mondef.GetTempInvSub(defaultHTTPInvestigatingTpl.Subject)
+	}
+
+	if mon.Template.Investigating.Message == defaultHTTPInvestigatingTpl.Message {
+		mon.Template.Investigating.Message = Mondef.GetTempInvMes(defaultHTTPInvestigatingTpl.Message)
+	}
+
+	if mon.Template.Fixed.Subject == defaultHTTPFixedTpl.Subject {
+		mon.Template.Fixed.Subject = Mondef.GetTempFixSub(defaultHTTPFixedTpl.Subject)
+	}
+
+	if mon.Template.Fixed.Message == defaultHTTPFixedTpl.Message {
+		mon.Template.Fixed.Message = Mondef.GetTempFixMes(defaultHTTPFixedTpl.Message)
+	}
 
 	if err := mon.Template.Fixed.Compile(); err != nil {
 		errs = append(errs, "Could not compile \"fixed\" template: "+err.Error())


### PR DESCRIPTION
Hi! 
I've created the new feature where we can set a list of "default" values and every monitor who doesn't have an explicited value will be fill with a default one. 

Major modifications:
  Created a new file called default.go; It's a simple copy from the basic AbstractMonitor struct; 
  Monitor.go now have a serie of validations to decide the data source (monitor or default_config); 

To implement this alterations simple add a section named 'default_config' as show below.
E.g.:
default_config:
  def_interval: 30
  def_timeout: 2
  def_history_size: 30
  def_threshold_critical: 80
  def_threshold_partial: 40
  def_expected_status_code: 200
  
  def_webhook:
    def_on_critical:
      def_on_critical_url: "https://url.defaulturl.com"
      def_on_critical_content_type: "text/plain"
      def_investigating:        
          def_message: "**{{ .Monitor.Name }}** * Your Default Message*: {{ .FailReason }}"
    def_on_partial:
      def_on_partial_url: "https://url.defaulturl.com"
      def_on_partial_content_type: "text/plain"
      def_investigating:        
          def_message: "**{{ .Monitor.Name }}** *Your Default Message*: {{ .FailReason }}"
  
  def_template:
    def_investigating:
      def_subject: "{{ .Monitor.Name }} - {{ .SystemName}}"
      def_message: "Service {{ .Monitor.Name }} failed  {{ .now }}. Investigating."
    def_fixed:
      def_subject: "Fixed"

Another behivior changed: 
Before your timeout values was assumed as nanoseconds, for exemple
interval: 30 was equal  30ns
Now 
interval:30 it's equal to 30s